### PR TITLE
added code and message fields to BalanceRespose POJO

### DIFF
--- a/overledger-sdk-api/src/main/java/network/quant/util/BalanceResponse.java
+++ b/overledger-sdk-api/src/main/java/network/quant/util/BalanceResponse.java
@@ -8,15 +8,19 @@ public class BalanceResponse {
     String address;
     String unit;
     BigDecimal value;
+    String code;
+    String message;
 
     public BalanceResponse() {
     }
 
-    public BalanceResponse(String dlt, String address, String unit, BigDecimal value) {
+    public BalanceResponse(String dlt, String address, String unit, BigDecimal value, String code, String message) {
         this.dlt = dlt;
         this.address = address;
         this.unit = unit;
         this.value = value;
+        this.code = code;
+        this.message = message;
     }
 
     public String getDlt() {
@@ -49,6 +53,22 @@ public class BalanceResponse {
 
     public void setValue(BigDecimal value) {
         this.value = value;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
     }
 
 }


### PR DESCRIPTION
https://app.clubhouse.io/quantnetwork/story/3363/java-sdk-balanceresponse-object-should-have-code-and-message-fields

added code and message fields to BalanceRespose POJO to avoid Jackson Exception while calling balance method.